### PR TITLE
Add `assetlinks.json` file

### DIFF
--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -1,0 +1,14 @@
+[
+  {
+    "relation": [
+      "delegate_permission/common.handle_all_urls"
+    ],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.boolder.boolder",
+      "sha256_cert_fingerprints": [
+        "AE:32:15:75:47:7E:5E:46:4B:DE:43:22:91:01:F6:D4:3E:38:D4:E2:2C:FE:7E:FE:B1:DF:F1:C0:23:8F:15:CB"
+      ]
+    }
+  }
+]


### PR DESCRIPTION
In order to be able to open Boolder deep links in the android app, a preliminary setup is needed, so that the auto-verification of the links can occur. It consists in serving a JSON file that lists the signing fingerprints of the apps that are allowed to handle the deep links from the same host.

The file is served at this address: `https://<host>/.well-known/assetlinks.json`

More info here:
https://developer.android.com/training/app-links/verify-android-applinks#web-assoc