### PR TITLE
Add Play store SHA256 fingerprint in `assetlinks.json` file

### DIFF
--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -7,7 +7,8 @@
       "namespace": "android_app",
       "package_name": "com.boolder.boolder",
       "sha256_cert_fingerprints": [
-        "AE:32:15:75:47:7E:5E:46:4B:DE:43:22:91:01:F6:D4:3E:38:D4:E2:2C:FE:7E:FE:B1:DF:F1:C0:23:8F:15:CB"
+        "AE:32:15:75:47:7E:5E:46:4B:DE:43:22:91:01:F6:D4:3E:38:D4:E2:2C:FE:7E:FE:B1:DF:F1:C0:23:8F:15:CB",
+        "FA:5C:C1:A9:48:72:C3:8C:3A:D0:C3:31:B2:C4:1B:19:C6:9B:5E:69:92:D1:13:2B:C2:CC:6C:B8:75:CE:59:99"
       ]
     }
   }


### PR DESCRIPTION
As the Play store also signs the release app, the associated SHA256 fingerprint has to be mentioned in the `assetlinks.json` file in order to make the deep links working.