### PR TITLE
Update deploy configuration to disable asset_path for CORS compatibility with CDN

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -88,7 +88,11 @@ aliases:
 # hitting 404 on in-flight requests. Combines all files from new and old
 # version inside the asset_path.
 #
-asset_path: /rails/public/assets
+# Disabled: serving assets through Rails allows rack-cors to add CORS headers,
+# which is required for assets served from a cross-origin CDN (assets.boolder.com).
+# CloudFront caches old assets, so bridging during deploys is still covered.
+#
+# asset_path: /rails/public/assets
 
 # Configure rolling deploys by setting a wait time between batches of restarts.
 #


### PR DESCRIPTION
Fix for https://github.com/boolder-org/boolder-rails/issues/112

# Root Cause

The Kamal proxy's asset_path feature ([config/deploy.yml](https://github.com/boolder-org/boolder-rails/compare/config/deploy.yml) line 91) serves static files directly from a shared volume, bypassing the Rails middleware stack entirely. This means rack-cors ([config/initializers/cors.rb](https://github.com/boolder-org/boolder-rails/compare/config/initializers/cors.rb)) never runs for asset requests, and no Access-Control-Allow-Origin header is added to the response.

Since the app uses importmap-rails (<script type="module">), the browser enforces CORS when loading JS from the cross-origin assets.boolder.com. The missing header causes the scripts to be blocked.

# Fix

Remove asset_path from [config/deploy.yml](https://github.com/boolder-org/boolder-rails/compare/config/deploy.yml) so asset requests flow through Puma/Rails, where rack-cors adds the CORS headers. CloudFront caches the responses (including the CORS headers), so the origin is rarely hit.

# Changes





[config/deploy.yml](https://github.com/boolder-org/boolder-rails/compare/config/deploy.yml) -- Remove or comment out asset_path: /rails/public/assets (line 91)

# Why this is safe





Performance: CloudFront caches fingerprinted assets with long TTLs, so the Rails origin is hit only on cache misses. The overhead of serving static files through Puma is negligible in practice.



Asset bridging during deploys: The asset_path feature bridges old/new fingerprinted assets to avoid 404s on in-flight requests. With CloudFront in front, old assets remain in the CDN cache during the deploy window, providing the same protection. Users with cached HTML referencing old asset digests will still get cache hits from CloudFront.