### PR TITLE
Fix CI: unpin brakeman, fix lint violation, repair stale test fixtures

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,7 +111,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
-    brakeman (7.0.0)
+    brakeman (8.0.5)
       racc
     breadcrumbs_on_rails (4.1.0)
       railties (>= 5.0)

--- a/db/migrate/20260206120000_add_topo_boulder_and_index.rb
+++ b/db/migrate/20260206120000_add_topo_boulder_and_index.rb
@@ -6,4 +6,3 @@ class AddTopoBoulderAndIndex < ActiveRecord::Migration[8.0]
     add_index :topos, :boulder_id
   end
 end
-

--- a/test/controllers/welcome_controller_test.rb
+++ b/test/controllers/welcome_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class WelcomeControllerTest < ActionDispatch::IntegrationTest
   test "should get index" do
-    get welcome_index_url
+    get root_localized_url(locale: "en")
     assert_response :success
   end
 end

--- a/test/fixtures/areas.yml
+++ b/test/fixtures/areas.yml
@@ -2,6 +2,8 @@
 
 one:
   name: MyString
+  bleau_area_id: 1
 
 two:
   name: MyString
+  bleau_area_id: 2

--- a/test/fixtures/pois.yml
+++ b/test/fixtures/pois.yml
@@ -1,15 +1,13 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  title: MyString
-  subtitle: MyString
-  description: MyString
-  location: MyString
-  route: MyString
+  name: MyString
+  short_name: MyString
+  google_url: MyString
+  poi_type: parking
 
 two:
-  title: MyString
-  subtitle: MyString
-  description: MyString
-  location: MyString
-  route: MyString
+  name: MyString
+  short_name: MyString
+  google_url: MyString
+  poi_type: parking

--- a/test/fixtures/problems.yml
+++ b/test/fixtures/problems.yml
@@ -3,7 +3,9 @@
 one:
   name: MyString
   grade: MyString
+  steepness: wall
 
 two:
   name: MyString
   grade: MyString
+  steepness: wall

--- a/test/fixtures/topos.yml
+++ b/test/fixtures/topos.yml
@@ -1,7 +1,7 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  line: 
+  published: true
 
 two:
-  line: 
+  published: true


### PR DESCRIPTION
Hi! I'm trying to set up the project locally to see if there's anything I can contribute. I noticed CI has been red on `main` for a while. Seems to be related to:

- `bin/brakeman` runs with `--ensure-latest`, so it fails once a newer version ships. Pinned gem was 7.0.0, latest is 8.0.5.
- Rubocop: trailing blank line in `db/migrate/20260206120000_add_topo_boulder_and_index.rb`.

Also fixed while setting up locally: several fixtures (`areas`, `pois`, `problems`, `topos`) were stale and no longer matched the schema, so `bin/rails test` errored out immediately for anyone running it. One test also referenced a dead route helper.

Verified locally: brakeman, rubocop, and `bin/rails test` all pass now.

Is there any issue or PR that you could use help with?